### PR TITLE
Close #2: added MetadataFromExceltoMediaWiki function to spreadsheets.py

### DIFF
--- a/example/Utility/MetadataFromExceltoMediaWiki.ipynb
+++ b/example/Utility/MetadataFromExceltoMediaWiki.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 4,
    "id": "80a91496-0a36-4ca6-8379-796aee6352c4",
    "metadata": {},
    "outputs": [],
@@ -26,12 +26,15 @@
     "import numpy as np\n",
     "import pandas as pd\n",
     "from pathlib import Path\n",
-    "from datetime import date"
+    "from datetime import date\n",
+    "\n",
+    "#Import  Spreadsheet Reformat function\n",
+    "from rsoxs_scans.spreadsheets import convertSampleSheetExcelMediaWiki"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 157,
+   "execution_count": 5,
    "id": "96f694d0-efa0-4ce4-a87d-da95ed78145e",
    "metadata": {},
    "outputs": [],
@@ -204,36 +207,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c5d77e9b-3210-4488-ba07-60dd57a3129a",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 76,
-   "id": "6ffc34d4-3b03-4456-94ba-e5f80d9b418e",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "[1]"
-      ]
-     },
-     "execution_count": 76,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "a = 1\n",
-    "[a]"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "8a9db714-6db7-4dbb-9a77-51c257b280e5",
    "metadata": {},
@@ -245,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 178,
+   "execution_count": 6,
    "id": "dabcf3fc-035e-4100-b26b-b443a56da39b",
    "metadata": {},
    "outputs": [
@@ -253,7 +226,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "== SST-1 Sample Sheet Syntax Version: 2023-1.1 Last Updated: 2023-01-06 ==\n",
+      "== SST-1 Sample Sheet Syntax Version: 2023-1.1 Last Updated: 2023-01-07 ==\n",
       "\n",
       "{| class=\"wikitable sortable\"\n",
       "|-\n",
@@ -661,7 +634,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "BP_pyDataScience",
    "language": "python",
    "name": "python3"
   },
@@ -675,7 +648,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.9.12"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "054bedd935cc4fb30a8577dfc7551b971df042c2fe48c0ba637d4f4d7d65a122"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION

Closes #2 

Finished Initial Scope of this feature. 

Usage: 

1. Import function: `from rsoxs_scans.spreadsheets import convertSampleSheetExcelMediaWiki`
2. Specify Excel Sheet path: `excelSheetInputPath = Path(r'../Sample_Bar_template_v2023_1_beta.xlsx')`
3. Run Function and print output: `print(convertSampleSheetExcelMediaWiki(excelSheetInputPath, verbose=False, paramsSheetToOutput='Acquisitions'))`
4. Copy paste output into mediawiki page


